### PR TITLE
Error handling on initial key load

### DIFF
--- a/OpenSSHA-GUI/ViewModels/MainWindowViewModel.cs
+++ b/OpenSSHA-GUI/ViewModels/MainWindowViewModel.cs
@@ -42,7 +42,13 @@ public class MainWindowViewModel : ViewModelBase
     public MainWindowViewModel()
     {
         RxApp.MainThreadScheduler.Schedule(Initialization);
-        _sshKeys = new ObservableCollection<SshPublicKey>(DirectoryCrawler.GetAllKeys());
+        _sshKeys = new ObservableCollection<SshPublicKey>(DirectoryCrawler.GetAllKeys(out var errors));
+
+        foreach (var error in errors)
+        {
+            Console.WriteLine($"Problem loading \"{error.File}\": {error.Exception.Message}");
+        }
+        
         _serverConnection = new ServerConnection("123", "123", "123");
         EvaluateAppropriateIcon();
     }

--- a/OpenSSHALib/Lib/DirectoryCrawler.cs
+++ b/OpenSSHALib/Lib/DirectoryCrawler.cs
@@ -1,14 +1,30 @@
 ﻿using OpenSSHALib.Extensions;
 using OpenSSHALib.Models;
+using Renci.SshNet.Security;
 
 namespace OpenSSHALib.Lib;
 
 public static class DirectoryCrawler
 {
-    public static IEnumerable<SshPublicKey> GetAllKeys()
+    public readonly record struct SshCrawlError(string File, Exception Exception);
+    
+    public static IEnumerable<SshPublicKey> GetAllKeys(out List<SshCrawlError> errors)
     {
+        var errorList = new List<SshCrawlError>();
+        errors = errorList;
         return Directory.EnumerateFiles(SshConfigFilesExtension.GetBaseSshPath(), "*.pub", SearchOption.AllDirectories)
-            .Select(
-                e => new SshPublicKey(e));
+            .Select(filePath =>
+            {
+                try
+                {
+                    return new SshPublicKey(filePath);
+                }
+                catch (Exception ex)
+                {
+                    errorList.Add(new SshCrawlError(filePath, ex));
+                    return null;
+                }
+            })
+            .Where(x => x != null)!;
     }
 }


### PR DESCRIPTION
It was failing to load for me after creating some PuTTY-style ssh key stuff for SourceTree, so I put in some super-simple error handling on the startup loading method